### PR TITLE
define urls with an array instead of patterns

### DIFF
--- a/oauth2_login_client/__init__.py
+++ b/oauth2_login_client/__init__.py
@@ -1,0 +1,1 @@
+app_config = 'apps.Config'

--- a/oauth2_login_client/apps.py
+++ b/oauth2_login_client/apps.py
@@ -1,0 +1,5 @@
+from django.apps import AppConfig
+
+class Config(AppConfig):
+    name = 'oauth2_login_client'
+    verbose_name = "OAuth2 login client"

--- a/oauth2_login_client/backends.py
+++ b/oauth2_login_client/backends.py
@@ -23,7 +23,7 @@ class OAuthBackend(ModelBackend):
             logging.warn("Error response from auth server")
             return None
 
-        userdata = json.loads(r.content)
+        userdata = json.loads(r.content.decode('UTF-8'))
 
         if not userdata or 'email' not in userdata or 'username' not in userdata:
             logging.warn("Username and email not returned by auth server")

--- a/oauth2_login_client/urls.py
+++ b/oauth2_login_client/urls.py
@@ -1,8 +1,8 @@
-from django.conf.urls import patterns
+from django.conf.urls import url, include
 from .views import login_redirect, account_redirect, login_callback
 
-urlpatterns = patterns('',
-    (r'^login/callback', login_callback),
-    (r'^login', login_redirect),
-    (r'^account', account_redirect),
-)
+urlpatterns = [
+    url(r'^login/callback', login_callback),
+    url(r'^login', login_redirect),
+    url(r'^account', account_redirect),
+]


### PR DESCRIPTION
Removes patterns, as it is deprecated since django 1.8. Also adds an app config which is required.