### PR TITLE
 Allow override redirect_uri for each authentication request

### DIFF
--- a/oauth2_login_client/backends.py
+++ b/oauth2_login_client/backends.py
@@ -8,21 +8,23 @@ from .utils import oauth_session, sync_user
 
 class OAuthBackend(ModelBackend):
 
-    def __init__(self):
-        self.oauth = oauth_session()
-
     def _extract_userdata(self, response):
         return response.json()
 
-    def authenticate(self, request=None, code=None):
-        token = self.oauth.fetch_token(
+    def authenticate(self, request=None, code=None, redirect_uri=None):
+        if redirect_uri is None:
+            oauth = oauth_session()
+        else:
+            oauth = oauth_session(redirect_uri=redirect_uri)
+
+        token = oauth.fetch_token(
             settings.OAUTH_SERVER + settings.OAUTH_TOKEN_URL,
             code=code,
             client_secret=settings.OAUTH_CLIENT_SECRET,
             verify=getattr(settings, 'OAUTH_VERIFY_SSL', True),
         )
 
-        r = self.oauth.get(settings.OAUTH_SERVER + settings.OAUTH_RESOURCE_URL)
+        r = oauth.get(settings.OAUTH_SERVER + settings.OAUTH_RESOURCE_URL)
         if r.status_code != 200:
             logging.warn("Error response from auth server")
             return None

--- a/oauth2_login_client/utils.py
+++ b/oauth2_login_client/utils.py
@@ -1,14 +1,25 @@
 from django.conf import settings
 from requests_oauthlib.oauth2_session import OAuth2Session
 
-def oauth_session(token=None):
+
+def oauth_session(
+    token=None,
+    client_id=settings.OAUTH_CLIENT_ID,
+    redirect_uri=settings.OAUTH_CALLBACK_URL,
+    auto_refresh_url=settings.OAUTH_SERVER + settings.OAUTH_TOKEN_URL,
+    scope=getattr(settings, 'OAUTH_SCOPE', None),
+    **kwargs
+):
+
     return OAuth2Session(
-        settings.OAUTH_CLIENT_ID,
-        redirect_uri=settings.OAUTH_CALLBACK_URL,
-        auto_refresh_url=settings.OAUTH_SERVER + settings.OAUTH_TOKEN_URL,
+        client_id=client_id,
+        redirect_uri=redirect_uri,
+        auto_refresh_url=auto_refresh_url,
         token=token,
-        scope=getattr(settings, 'OAUTH_SCOPE', None),
+        scope=scope,
+        **kwargs
     )
+
 
 def get_login_url():
     oauth = oauth_session()

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ LONG_DESCRIPTION = open('README.md').read()
 
 setup(
     name="django-oauth2-login-client",
-    version="0.4.1",
+    version="0.5.0",
     description="OAuth2 consumer for authentication by a django-oauth-toolkit site",
     long_description=LONG_DESCRIPTION,
     classifiers=[


### PR DESCRIPTION
I revert back `oauth_session()` instanciation for each authentication cause this allow simplify logic.

`oauth_session()` signature is extended, `token` param still first for backward compatibility