### PR TITLE
allow override `sync_user` behaviour

### DIFF
--- a/oauth2_login_client/backends.py
+++ b/oauth2_login_client/backends.py
@@ -6,10 +6,14 @@ from django.contrib.auth.backends import ModelBackend
 from .models import RemoteUser
 from .utils import oauth_session, sync_user
 
+
 class OAuthBackend(ModelBackend):
 
     def _extract_userdata(self, response):
         return response.json()
+
+    def _sync_user(self, user, userdata):
+        sync_user(user, userdata)
 
     def authenticate(self, request=None, code=None, redirect_uri=None):
         if redirect_uri is None:
@@ -64,7 +68,7 @@ class OAuthBackend(ModelBackend):
                 user=user, remote_username = userdata['username'])
             user.remoteuser.save()
 
-        sync_user(user, userdata)
+        self._sync_user(user, userdata)
 
         # Send the token back along with the user
         user.oauth_token = token

--- a/oauth2_login_client/middleware.py
+++ b/oauth2_login_client/middleware.py
@@ -10,10 +10,14 @@ except ImportError:
 
 from .utils import oauth_session, sync_user
 
+
 class OAuthMiddleware(MiddlewareMixin):
     """If user details are stale, fetch and synchronise from the oauth server.
     If the user is no longer allowed to authenticate with the auth server, log
     them out."""
+
+    def _sync_user(self, user, userdata):
+        sync_user(user, userdata)
 
     def process_request(self, request):
         if not request.user.is_authenticated:
@@ -61,6 +65,6 @@ class OAuthMiddleware(MiddlewareMixin):
             logging.warn("Username mismatch")
             return logout(request)
 
-        sync_user(request.user, userdata)
+        self._sync_user(request.user, userdata)
         request.session['oauth_user_data'] = dict(synced_at=time.time())
         return

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ LONG_DESCRIPTION = open('README.md').read()
 
 setup(
     name="django-oauth2-login-client",
-    version="0.5.0",
+    version="0.6.0",
     description="OAuth2 consumer for authentication by a django-oauth-toolkit site",
     long_description=LONG_DESCRIPTION,
     classifiers=[


### PR DESCRIPTION
For some cases we need update extra info for user provided by oauth server.
This PR allow customize this process.

Usefull for cases:

 - Update existing User model
 - Ignore updating (set userdata on object instance like `oauth_token` was set now)
 - Update additional model(s)
 - Any other