### PR TITLE
move `create_user` logic to utils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ LONG_DESCRIPTION = open('README.md').read()
 
 setup(
     name="django-oauth2-login-client",
-    version="0.6.0",
+    version="0.7.0",
     description="OAuth2 consumer for authentication by a django-oauth-toolkit site",
     long_description=LONG_DESCRIPTION,
     classifiers=[


### PR DESCRIPTION
Here is new improvement ;)

So, in some cases i got user details from another place (not from oauth) and whant to save it in database, but i want allow users auth with same credentials later (email, username).